### PR TITLE
Replace localhost with explicit 127.0.0.1

### DIFF
--- a/start-catberry.sh
+++ b/start-catberry.sh
@@ -1,9 +1,9 @@
-cd ./catberry && 
-node ./server.js & 
-(sleep 3s && 
-	echo "===Catberry===" > ./results/catberry.txt && 
-	ab -c 10 -n 3000 http://localhost:3001/ >> ./results/catberry.txt && 
-	cd .. && 
-	echo "Saved in ./results/catberry.txt" 
+cd ./catberry &&
+node ./server.js &
+(sleep 3s &&
+	echo "===Catberry===" > ./results/catberry.txt &&
+	ab -c 10 -n 3000 http://127.0.0.1:3001/ >> ./results/catberry.txt && 
+	cd .. &&
+	echo "Saved in ./results/catberry.txt"
 )
 wait

--- a/start-express.sh
+++ b/start-express.sh
@@ -1,9 +1,9 @@
-cd ./express && 
-node ./index.js & 
-(sleep 3s && 
-	echo "===Express===" > ./results/express.txt && 
-	ab -c 10 -n 3000 http://localhost:3000/ >> ./results/express.txt && 
-	cd .. && 
-	echo "Saved in ./results/express.txt" 
+cd ./express &&
+node ./index.js &
+(sleep 3s &&
+	echo "===Express===" > ./results/express.txt &&
+	ab -c 10 -n 3000 http://127.0.0.1:3000/ >> ./results/express.txt && 
+	cd .. &&
+	echo "Saved in ./results/express.txt"
 )
 wait


### PR DESCRIPTION
I had the following error while trying to run benchmarks:

```
$ ./start-catberry.sh
apr_socket_recv: Connection refused (111)
```

The error was fixed by this patch.

That's a known problem but it seems that it is not fixed still in ab 2.3. If it matters, my OS is Fedora 21:

```
$ cat /etc/issue
Fedora release 21 (Twenty One)
Kernel \r on an \m (\l)
$ uname -a
Linux localhost.localdomain 3.17.4-301.fc21.x86_64 #1 SMP Thu Nov 27 19:09:10 UTC 2014 x86_64 x86_64 x86_64 GNU/Linux
$ ab -V
This is ApacheBench, Version 2.3 <$Revision: 1638069 $>
```
